### PR TITLE
Update activemq-client version

### DIFF
--- a/amq-helloworld-jms/pom.xml
+++ b/amq-helloworld-jms/pom.xml
@@ -71,6 +71,7 @@
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-client</artifactId>
+			<version>5.11.0.redhat-621107</version>
 		</dependency>
 		
 		<!-- Logging -->


### PR DESCRIPTION
Out of the box example is not working without the version specified. It looks for version 5.11.0.redhat-620133 which is not present on this repository: http://maven.repository.redhat.com/earlyaccess/all 
(this repo is specified in the A-MQ Getting Started guide ( [http://developers.redhat.com/products/amq/get-started/](http://developers.redhat.com/products/amq/get-started/)  ))
